### PR TITLE
Added Python3 version of json2yaml.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Now that NSO in in sync, we can start fetching data to use in our playbooks. The
 ```
 curl -s -u admin:admin -H "Accept: application/vnd.yang.data+json" http://localhost:8080/api/config/devices/device/jnpr0/config?deep
 curl -s -u admin:admin -H "Accept: application/vnd.yang.data+json" http://localhost:8080/api/config/devices/device/jnpr0/config?deep | ../json2yaml.py
-or with Python3
+or with Python3:
 curl -s -u admin:admin -H "Accept: application/vnd.yang.data+json" http://localhost:8080/api/config/devices/device/jnpr0/config?deep | ../json2yaml3.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Now that NSO in in sync, we can start fetching data to use in our playbooks. The
 ```
 curl -s -u admin:admin -H "Accept: application/vnd.yang.data+json" http://localhost:8080/api/config/devices/device/jnpr0/config?deep
 curl -s -u admin:admin -H "Accept: application/vnd.yang.data+json" http://localhost:8080/api/config/devices/device/jnpr0/config?deep | ../json2yaml.py
+or with Python3
+curl -s -u admin:admin -H "Accept: application/vnd.yang.data+json" http://localhost:8080/api/config/devices/device/jnpr0/config?deep | ../json2yaml3.py
 ```
 
 Paste the output into the template playbook `verify-device-tmpl.yaml` and put it under the line with the device name. Remember to indent correctly so you don't break the YAML whitespace.

--- a/json2yaml3.py
+++ b/json2yaml3.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import json
+import sys
+import yaml
+
+
+def _utf8_encode(obj):
+    if obj is None:
+        return None
+    if type(obj) is str:
+        return obj
+    if type(obj) is list:
+        return [_utf8_encode(value) for value in obj]
+    if type(obj) is dict:
+        obj_dest = {}
+        for key, value in obj.items():
+            if not 'EXEC' in key.upper() :
+                obj_dest[_utf8_encode(key)] = _utf8_encode(value)
+        return obj_dest
+    return obj
+
+
+def main():
+    obj = json.load(sys.stdin)
+    utf8_obj = _utf8_encode(obj)
+    yaml.dump(utf8_obj, stream=sys.stdout,
+              default_flow_style=False, explicit_start=False)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
json2yaml.py does not work with Python3 so I modified it and added as json2yaml3.py.   Trying to make the one file do both is something perhaps for another time.   This addition plus a small change to nso.py in the ansible module_utils make this work with Python 3.5.  

Tested with virtualenv Python2.7 and Python3.5 and use case examples in the README.